### PR TITLE
Match static file requests aginst 'upload' for path traversal protection

### DIFF
--- a/multicore_runtime/static_files.py
+++ b/multicore_runtime/static_files.py
@@ -24,16 +24,19 @@ from werkzeug.wrappers import Response
 from werkzeug.wsgi import wrap_file
 
 
-def static_app_for_regex_and_files(regex, files, mime_type=None):
+def static_app_for_regex_and_files(regex, files, upload, mime_type=None):
   """Returns a WSGI app that serves static files.
 
   Args:
     regex: A url-matching regex as specified in appinfo.URLMap.
     files: A static_files definition as specified in appinfo.URLMap.
-        May include a regex backref. See the appinfo.URLMap docstring
-        for more information.
+      May include a regex backref. See the appinfo.URLMap docstring
+      for more information.
+    upload: A filename-matching regex as specified in appinfo.URLMap.
+      Only files that match this regex will be served regardless of other
+      arguments.
     mime_type: A mime type to apply to all files. If absent,
-        mimetypes.guess_type() is used.
+      mimetypes.guess_type() is used.
 
   Returns:
     A static file-serving WSGI app closed over the inputs.
@@ -46,13 +49,12 @@ def static_app_for_regex_and_files(regex, files, mime_type=None):
     # ... and use the files regex backref to choose a filename.
     filename = matcher.expand(files)
 
-    # Rudimentary protection against path traversal outside of the app. This
-    # code should never be hit in production, as Google's frontend servers
-    # (GFE) rewrite traversal attempts and respond with a 302 immediately.
-    filename = os.path.abspath(filename)
-    if not filename.startswith(os.path.join(os.getcwd(), '')):
-      logging.warn('Path traversal protection triggered for %s, '
-                   'returning 404', filename)
+    # Check to see if the normalized path matched is in the upload regex.
+    # This provides path traversal protection, although apps running on Google
+    # servers are protected by the Google frontend (GFE)'s own path traversal
+    # protection as well.
+    if not re.match(upload, os.path.normpath(filename)):
+      logging.warn('Requested filename %s not in `upload`', filename)
       return Response(status=404)
 
     try:

--- a/multicore_runtime/wsgi_config.py
+++ b/multicore_runtime/wsgi_config.py
@@ -94,6 +94,7 @@ def static_app_for_handler(handler):
   """
   regex = handler.url
   files = handler.static_files
+  upload = handler.upload
   if not files:
     if handler.static_dir:
       # If static_files is not set, convert static_dir to static_files and also
@@ -101,12 +102,13 @@ def static_app_for_handler(handler):
       # more information.
       regex = static_dir_url(handler)
       files = handler.static_dir + r'/\1'
+      upload = handler.static_dir + '/.*'
     else:
       # Neither static_files nor static_dir is set; log an error and return.
       logging.error('No script, static_files or static_dir found for %s',
                     handler)
       return None
-  return static_app_for_regex_and_files(regex, files,
+  return static_app_for_regex_and_files(regex, files, upload,
                                         mime_type=handler.mime_type)
 
 

--- a/multicore_runtime/wsgi_test.py
+++ b/multicore_runtime/wsgi_test.py
@@ -39,11 +39,15 @@ FAKE_HANDLERS = [
                    login=appinfo.LOGIN_REQUIRED),
     appinfo.URLMap(url='/admin', script='wsgi_test.hello_world',
                    login=appinfo.LOGIN_ADMIN),
-    appinfo.URLMap(url='/favicon.ico', static_files='test_statics/favicon.ico'),
+    appinfo.URLMap(url='/favicon.ico',
+                   static_files='test_statics/favicon.ico',
+                   upload='test_statics/favicon.ico'),
     appinfo.URLMap(url='/faketype.ico', static_files='test_statics/favicon.ico',
-                   mime_type='application/fake_type'),
+                   mime_type='application/fake_type',
+                   upload='test_statics/favicon.ico'),
     appinfo.URLMap(url='/wildcard_statics/(.*)',
-                   static_files=r'test_statics/\1'),
+                   static_files=r'test_statics/\1',
+                   upload='test_statics/(.*)'),
     appinfo.URLMap(url='/static_dir',
                    static_dir='test_statics'),
     ]
@@ -176,7 +180,10 @@ class MetaAppTestCase(unittest.TestCase):
     self.assertEqual(response.status_code, 404)
 
   def test_static_file_wildcard_directory_traversal(self):
+    # Try to fetch some files outside of the "upload" regex using path traversal
     response = self.client.get('/wildcard_statics/../../setup.py')
+    self.assertEqual(response.status_code, 404)
+    response = self.client.get('/wildcard_statics/../__init__.py')
     self.assertEqual(response.status_code, 404)
 
   def test_static_dir(self):


### PR DESCRIPTION
R: @gbin CC: @isdal