### PR TITLE
Handle lack of Cloud Logging support gracefully and force log level to INFO

### DIFF
--- a/multicore_runtime/cloud_logging.py
+++ b/multicore_runtime/cloud_logging.py
@@ -43,7 +43,7 @@ class CloudLoggingHandler(logging.FileHandler):
     # Large log entries will get mangled if multiple workers write to the same
     # file simultaneously, so we'll use the worker's PID to pick a log filename.
     filename = LOG_PATH_TEMPLATE.format(os.getpid())
-    super(CloudLoggingHandler, self).__init__(filename, delay=True)
+    super(CloudLoggingHandler, self).__init__(filename)
 
   def format(self, record):
     """Format the specified record default behavior, plus JSON and metadata."""

--- a/multicore_runtime/wsgi.py
+++ b/multicore_runtime/wsgi.py
@@ -38,9 +38,16 @@ from google.appengine.ext.vmruntime import vmconfig
 from google.appengine.ext.vmruntime import vmstub
 
 # Configure logging to output structured JSON to Cloud Logging.
-handler = cloud_logging.CloudLoggingHandler()
-handler.setLevel(logging.INFO)
-logging.getLogger('').addHandler(handler)
+root_logger = logging.getLogger('')
+try:
+    handler = cloud_logging.CloudLoggingHandler()
+    root_logger.addHandler(handler)
+except IOError:
+    # If the Cloud Logging endpoint does not exist, just use the default handler
+    # instead. This will be the case when running in local dev mode.
+    pass
+
+root_logger.setLevel(logging.INFO)
 
 # Fetch application configuration via the config file.
 appinfo = get_module_config(get_module_config_filename())


### PR DESCRIPTION
This resolves an issue where logging was not configured on the root node, causing lower-priority logs to be skipped.

R: @apolito CC: @isdal @hazarm