### PR TITLE
Remove restrictions on admin/login paths

### DIFF
--- a/multicore_runtime/wsgi_config.py
+++ b/multicore_runtime/wsgi_config.py
@@ -150,23 +150,18 @@ def load_user_scripts_into_handlers(handlers):
       - url_re: The url regular expression which matches this handler.
       - app: The fully loaded app corresponding to the script.
   """
-  # `if handler.login == appinfo.LOGIN_OPTIONAL` disables loading handlers
-  # that require login or admin status entirely. This is a temporary
-  # measure until handling of login-required handlers is implemented
-  # securely.
   loaded_handlers = []
   for handler in handlers:
-    if handler.login == appinfo.LOGIN_OPTIONAL:
-      if handler.script:  # An application, not a static files directive.
+    if handler.script:  # An application, not a static files directive.
+      url_re = handler.url
+      app = app_for_script(handler.script)
+    else:  # A static files directive, either with static_files or static_dir.
+      if handler.static_files:
         url_re = handler.url
-        app = app_for_script(handler.script)
-      else:  # A static files directive, either with static_files or static_dir.
-        if handler.static_files:
-          url_re = handler.url
-        else:  # This is a "static_dir" directive.
-          url_re = static_dir_url_re(handler)
-        app = static_app_for_handler(handler)
-      loaded_handlers.append((url_re, app))
+      else:  # This is a "static_dir" directive.
+        url_re = static_dir_url_re(handler)
+      app = static_app_for_handler(handler)
+    loaded_handlers.append((url_re, app))
   logging.info('Parsed handlers: %r',
                [url_re for (url_re, _) in loaded_handlers])
   return loaded_handlers

--- a/multicore_runtime/wsgi_test.py
+++ b/multicore_runtime/wsgi_test.py
@@ -48,10 +48,6 @@ FAKE_HANDLERS = [
     appinfo.URLMap(url='/sortenv', script=script_path('sort_os_environ_keys')),
     appinfo.URLMap(url='/setenv', script=script_path('add_to_os_environ')),
     appinfo.URLMap(url='/wait', script=script_path('wait_on_global_event')),
-    appinfo.URLMap(url='/login', script=script_path('hello_world'),
-                   login=appinfo.LOGIN_REQUIRED),
-    appinfo.URLMap(url='/admin', script=script_path('hello_world'),
-                   login=appinfo.LOGIN_ADMIN),
     appinfo.URLMap(url='/favicon.ico',
                    static_files=static_path('test_statics/favicon.ico'),
                    upload=static_path('test_statics/favicon.ico')),
@@ -170,16 +166,6 @@ class MetaAppTestCase(unittest.TestCase):
     response = self.client.get('/env')
     # Assumes PATH will be present in the env in all cases, including tests!
     self.assertIn('PATH', json.loads(response.data))
-
-  def test_login_required(self):
-    # Login routes are temporarily disabled.
-    response = self.client.get('/login')
-    self.assertEqual(response.status_code, httplib.NOT_FOUND)
-
-  def test_login_admin(self):
-    # Login routes are temporarily disabled.
-    response = self.client.get('/admin')
-    self.assertEqual(response.status_code, httplib.NOT_FOUND)
 
   def test_static_file(self):
     response = self.client.get('/favicon.ico')


### PR DESCRIPTION
Security barrier for these routes is now outside container. The runtime won't look at the login status at all when registering handlers or dispatching.

R: @apolito @dlorenc
CC: @bryanmau1 @isdal