### PR TITLE
Upgrade static handler

### DIFF
--- a/multicore_runtime/static_files.py
+++ b/multicore_runtime/static_files.py
@@ -44,12 +44,13 @@ def static_app_for_regex_and_files(url_re, files_mapping, upload_re,
     mime_type: A mime type to apply to all files. If absent,
       mimetypes.guess_type() is used.
     http_headers: dictionary of header keys and values.
-    expiration: String of form 'Xd Yh Zs' as public documentation states.
+    expiration: datetime.timedelta object representing how long the static
+      asset ought to be cached.
 
   Returns:
     A static file-serving WSGI app closed over the inputs.
   """
-  @wrappers.Request.application  # Transforms wsgi_env, start_response args into request
+  @wrappers.Request.application
   def serve_static_files(request):
     """Serve a static file."""
     # First, match the path against the regex.
@@ -82,8 +83,7 @@ def static_app_for_regex_and_files(url_re, files_mapping, upload_re,
     if http_headers:
       headers.extend(http_headers)
     elif expiration:
-      expires = datetime.datetime.now() + datetime.timedelta(
-          seconds=expiration)
+      expires = datetime.datetime.now() + expiration
       headers['Expires'] = http.http_date(expires)
 
     wrapped_file = wsgi.wrap_file(request.environ, fp)

--- a/multicore_runtime/static_files.py
+++ b/multicore_runtime/static_files.py
@@ -14,18 +14,23 @@
 #
 """Static file serving functionality invoked by wsgi_config.py."""
 
+import datetime
 import httplib
 import logging
 import mimetypes
 import os
 import re
 
+from werkzeug import datastructures
+from werkzeug import http
 from werkzeug import wrappers
 from werkzeug import wsgi
 
 
 def static_app_for_regex_and_files(url_re, files_mapping, upload_re,
-                                   mime_type=None):
+                                   mime_type=None,
+                                   http_headers=None,
+                                   expiration=None):
   """Returns a WSGI app that serves static files.
 
   Args:
@@ -71,8 +76,17 @@ def static_app_for_regex_and_files(url_re, files_mapping, upload_re,
       logging.warn('Requested non-existent filename %s', filename)
       return wrappers.Response(status=httplib.NOT_FOUND)
 
+    headers = datastructures.Headers()
+    if http_headers:
+      headers.extend(http_headers)
+    elif expiration:
+      expires = datetime.datetime.now() + datetime.timedelta(
+          seconds=expiration)
+      headers['Expires'] = http.http_date(expires)
+
     wrapped_file = wsgi.wrap_file(request.environ, fp)
     return wrappers.Response(
         wrapped_file, direct_passthrough=True,
-        mimetype=mime_type or mimetypes.guess_type(filename)[0])
+        mimetype=mime_type or mimetypes.guess_type(filename)[0],
+        headers=headers)
   return serve_static_files

--- a/multicore_runtime/static_files.py
+++ b/multicore_runtime/static_files.py
@@ -43,6 +43,8 @@ def static_app_for_regex_and_files(url_re, files_mapping, upload_re,
       arguments.
     mime_type: A mime type to apply to all files. If absent,
       mimetypes.guess_type() is used.
+    http_headers: dictionary of header keys and values.
+    expiration: String of form 'Xd Yh Zs' as public documentation states.
 
   Returns:
     A static file-serving WSGI app closed over the inputs.

--- a/multicore_runtime/wsgi.py
+++ b/multicore_runtime/wsgi.py
@@ -82,7 +82,7 @@ if appinfo.vm_settings.get('vm_runtime') == 'python':
       appinfo.handlers)
 else:
   preloaded_handlers = wsgi_config.load_user_scripts_into_handlers(
-      appinfo.handlers)
+      appinfo)
 
 # Now that all scripts are fully imported, it is safe to use asynchronous
 # API calls.

--- a/multicore_runtime/wsgi_config.py
+++ b/multicore_runtime/wsgi_config.py
@@ -117,8 +117,15 @@ def static_app_for_handler(handler):
       logging.error('No script, static_files or static_dir found for %s',
                     handler)
       return None
+  if handler.expiration:
+    expiration = appinfo.ParseExpiration(handler.expiration)
+  else:
+    expiration = None
   return static_files.static_app_for_regex_and_files(
-      url_re, files, upload_re, mime_type=handler.mime_type)
+      url_re, files, upload_re,
+      mime_type=handler.mime_type,
+      http_headers=handler.http_headers,
+      expiration=expiration)
 
 
 def static_dir_url_re(handler):

--- a/multicore_runtime/wsgi_config.py
+++ b/multicore_runtime/wsgi_config.py
@@ -97,6 +97,7 @@ def static_app_for_handler(handler, default_expire=None):
   Args:
     handler: An individual handler from appinfo_external.handlers
       (appinfo.URLMap)
+    default_expire: A top-level default expiration time for static assets.
 
   Returns:
     A static file-serving WSGI app closed over the handler information.
@@ -149,7 +150,7 @@ def load_user_scripts_into_handlers(appinfo):
   """Preloads user scripts, wrapped in env_config middleware if present.
 
   Args:
-    handlers: appinfo.handlers data as provided by get_module_config()
+    appinfo: AppInfoExternal object mostly used to get it's handlers.
 
   Returns:
     A list of tuples suitable for configuring the dispatcher() app,

--- a/multicore_runtime/wsgi_config.py
+++ b/multicore_runtime/wsgi_config.py
@@ -147,11 +147,11 @@ def static_dir_url_re(handler):
     return handler.url
 
 
-def load_user_scripts_into_handlers(app):
+def load_user_scripts_into_handlers(app_info):
   """Preloads user scripts, wrapped in env_config middleware if present.
 
   Args:
-    app: AppInfoExternal object mostly used to get it's handlers.
+    app_info: AppInfoExternal object mostly used to get it's handlers.
 
   Returns:
     A list of tuples suitable for configuring the dispatcher() app,
@@ -160,7 +160,7 @@ def load_user_scripts_into_handlers(app):
       - app: The fully loaded app corresponding to the script.
   """
   loaded_handlers = []
-  for handler in app.handlers:
+  for handler in app_info.handlers:
     if handler.script:  # An application, not a static files directive.
       url_re = handler.url
       app = app_for_script(handler.script)
@@ -170,7 +170,7 @@ def load_user_scripts_into_handlers(app):
       else:  # This is a "static_dir" directive.
         url_re = static_dir_url_re(handler)
       app = static_app_for_handler(handler,
-                                   default_expire=app.default_expiration)
+                                   default_expire=app_info.default_expiration)
     loaded_handlers.append((url_re, app))
   logging.info('Parsed handlers: %r',
                [url_re for (url_re, _) in loaded_handlers])

--- a/multicore_runtime/wsgi_test.py
+++ b/multicore_runtime/wsgi_test.py
@@ -212,10 +212,8 @@ class MetaAppTestCase(unittest.TestCase):
     self.assertTrue(response.headers.has_key('X-Bar-Header'))
     self.assertEqual(response.headers['X-Bar-Header'], 'bar value')
 
+  @patch('datetime.datetime', FakeDatetime)
   def test_static_file_expires(self):
-    # Patching the datetime class
-    datetime.datetime = FakeDatetime
-
     response = self.client.get('/expiration')
     self.assertEqual(response.status_code, httplib.OK)
     with open(static_path('test_statics/favicon.ico')) as f:
@@ -227,10 +225,8 @@ class MetaAppTestCase(unittest.TestCase):
     self.assertEqual(response.headers['Expires'],
                      http.http_date(expired_time))
 
+  @patch('datetime.datetime', FakeDatetime)
   def test_static_file_default_expires(self):
-    # Patching the datetime class
-    datetime.datetime = FakeDatetime
-
     response = self.client.get('/favicon.ico')
     self.assertEqual(response.status_code, httplib.OK)
     with open(static_path('test_statics/favicon.ico')) as f:

--- a/multicore_runtime/wsgi_test.py
+++ b/multicore_runtime/wsgi_test.py
@@ -94,7 +94,8 @@ WRONG_IP = '192.168.0.1'
 
 FAKE_APPINFO_EXTERNAL = MagicMock(handlers=FAKE_HANDLERS,
                                   env_variables={FAKE_ENV_KEY: FAKE_ENV_VALUE,
-                                                 'USER_EMAIL': BAD_USER_EMAIL})
+                                                 'USER_EMAIL': BAD_USER_EMAIL},
+                                  default_expiration='2d 3h')
 
 FAKE_APPENGINE_CONFIG = MagicMock(
     server_software='server', partition='partition', appid='appid',
@@ -223,6 +224,20 @@ class MetaAppTestCase(unittest.TestCase):
     expired_time = current_time + extra_time
     self.assertEqual(response.headers['Expires'],
                      http.http_date(expired_time))
+
+  def test_static_file_default_expires(self):
+    response = self.client.get('/favicon.ico')
+    self.assertEqual(response.status_code, httplib.OK)
+    with open(static_path('test_statics/favicon.ico')) as f:
+      self.assertEqual(response.data, f.read())
+    current_time = FAKE_CURRENT_TIME
+    extra_time = datetime.timedelta(
+        seconds=appinfo.ParseExpiration('2d 3h'))
+    expired_time = current_time + extra_time
+    self.assertEqual(response.headers['Expires'],
+                     http.http_date(expired_time))
+
+
 
 
   def test_static_file_wildcard(self):

--- a/multicore_runtime/wsgi_test.py
+++ b/multicore_runtime/wsgi_test.py
@@ -31,13 +31,12 @@ from werkzeug import wrappers
 
 from google.appengine.api import appinfo
 
+
 class FakeDatetime(datetime.datetime):
 
   @staticmethod
   def now():
     return FAKE_CURRENT_TIME
-
-datetime.datetime = FakeDatetime
 
 
 def script_path(script, test_name=__name__):
@@ -214,6 +213,9 @@ class MetaAppTestCase(unittest.TestCase):
     self.assertEqual(response.headers['X-Bar-Header'], 'bar value')
 
   def test_static_file_expires(self):
+    # Patching the datetime class
+    datetime.datetime = FakeDatetime
+
     response = self.client.get('/expiration')
     self.assertEqual(response.status_code, httplib.OK)
     with open(static_path('test_statics/favicon.ico')) as f:
@@ -226,6 +228,9 @@ class MetaAppTestCase(unittest.TestCase):
                      http.http_date(expired_time))
 
   def test_static_file_default_expires(self):
+    # Patching the datetime class
+    datetime.datetime = FakeDatetime
+
     response = self.client.get('/favicon.ico')
     self.assertEqual(response.status_code, httplib.OK)
     with open(static_path('test_statics/favicon.ico')) as f:
@@ -236,9 +241,6 @@ class MetaAppTestCase(unittest.TestCase):
     expired_time = current_time + extra_time
     self.assertEqual(response.headers['Expires'],
                      http.http_date(expired_time))
-
-
-
 
   def test_static_file_wildcard(self):
     response = self.client.get('/wildcard_statics/favicon.ico')


### PR DESCRIPTION
Implementation of #33 
Brought our static handler up to feature parity with classic appengine.  Specifically, headers and expiration per static handler have been implemented as well as a top level default expiration for all handlers in the absence of an explicit expiration.

R: @andrewsg  CC: @jcollins-g 