### PR TITLE
Upgrade to gunicorn 19.4.1 to fix gunicorn issue 1011

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -q update && \
 COPY python-runtime.tar.gz /home/vmagent/python-runtime.tar.gz
 
 RUN easy_install pip
-RUN pip install gunicorn==19.3.0 futures==3.0.3
+RUN pip install gunicorn==19.4.1 futures==3.0.3
 RUN pip install google-python-cloud-debugger
 RUN pip install /home/vmagent/python-runtime.tar.gz
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,10 +1,10 @@
 import multiprocessing
 
-# Use the default worker + threads. Thread-based concurrency is provided via
-# the 'futures' package. 'gevent' or other workers would be candidates, except
-# that the ndb library has its own concurrency model that conflicts with gevent
-# and possibly similar approaches.
-worker_class = 'sync'
+# Use threaded workers. Thread-based concurrency is provided via the 'futures'
+# package. 'gevent' or other workers would be candidates, except that the ndb
+# library has its own concurrency model that conflicts with gevent and possibly
+# with similar approaches.
+worker_class = 'gthread'
 
 # Use a number of workers equal to the number of CPU cores available.
 # Reducing this number on a multicore instance will reduce memory consumption,
@@ -12,10 +12,8 @@ worker_class = 'sync'
 workers = multiprocessing.cpu_count()
 
 # Use an arbitrary number of threads for concurrency. This will dictate the
-# maximum number of requests handled concurrently by EACH worker. Consider
-# increasing this number for applications that spend a lot of time waiting for
-# I/O.
-threads = 100
+# maximum number of requests handled concurrently by EACH worker.
+threads = 25
 
 # Settings specific to the Managed VMs production environment such as "bind"
 # and "logfile" are set in the Dockerfile's ENTRYPOINT directive.

--- a/multicore_runtime/dev/Dockerfile
+++ b/multicore_runtime/dev/Dockerfile
@@ -12,7 +12,7 @@ ADD https://github.com/GoogleCloudPlatform/appengine-python-vm-runtime/releases/
 # COPY appengine-python-vm-runtime-0.2.tar.gz /home/vmagent/python-runtime.tar.gz
 
 RUN easy_install pip
-RUN pip install gunicorn==19.3.0 futures==3.0.3
+RUN pip install gunicorn==19.4.1 futures==3.0.3
 RUN pip install google-python-cloud-debugger
 RUN pip install /home/vmagent/python-runtime.tar.gz
 


### PR DESCRIPTION
Gunicorn issue 1011 (https://github.com/benoitc/gunicorn/issues/1011) was keeping us from declaring "gthread" workers properly in gunicorn.conf.py, even though we were using gthread workers regardless via a workaround (it's selected by default if you set threads > 1).

Also reduce thread count to a more general-purpose number. Previously it was increased to 100 to resolve a specific issue that no longer exists.

R: @bryanmau1 CC: @jcollins-g 