### PR TITLE
Fix option to disable ssl validation in devserver urlfetch

### DIFF
--- a/appengine-compat/exported_appengine_sdk/google/appengine/api/urlfetch_stub.py
+++ b/appengine-compat/exported_appengine_sdk/google/appengine/api/urlfetch_stub.py
@@ -42,6 +42,7 @@ import logging
 import os
 import socket
 import StringIO
+import ssl
 import sys
 import urllib
 import urlparse
@@ -416,8 +417,11 @@ class URLFetchServiceStub(apiproxy_stub.APIProxyStub):
 
 
 
-        connection_kwargs = (
-            {'timeout': deadline} if _CONNECTION_SUPPORTS_TIMEOUT else {})
+        connection_kwargs = {}
+        if _CONNECTION_SUPPORTS_TIMEOUT:
+          connection_kwargs['timeout'] = deadline
+        if not validate_certificate:
+          connection_kwargs['context'] = ssl._create_unverified_context()
 
         if proxy_host:
           proxy_address, _, proxy_port = proxy_host.partition(':')


### PR DESCRIPTION
The devserver urlfetch stub does not currently honour the
AllowInvalidServerCertificate option. This likely came from a breaking
change to httplib
(https://docs.python.org/2/library/httplib.html#httplib.HTTPSConnection).
Specifically, "This class now performs all the necessary certificate and
hostname checks by default. To revert to the previous, unverified,
behavior ssl._create_unverified_context() can be passed to the context
parameter."

This PR passes the unverified context when the caller specifies to allow
invalid certs.

(I'm not sure if this is the right place for this PR, but this is still broken in the latest devserver in the latest [gcloud docker image](https://hub.docker.com/r/google/cloud-sdk/) and I couldn't find the source code for that.)